### PR TITLE
Fix the link to cloc github project

### DIFF
--- a/app/_posts/2015-12-04-dotcss-2015.md
+++ b/app/_posts/2015-12-04-dotcss-2015.md
@@ -387,7 +387,7 @@ again next year.
 [15]: /img/2015-12-04/daniel.jpg
 [16]: https://www.etsy.com/
 [17]: /img/2015-12-04/css.gif
-[18]: https://github.com/AlDanial/cloc)
+[18]: https://github.com/AlDanial/cloc
 [19]: http://cssstats.com/
 [20]: https://github.com/katiefenn/parker
 [21]: https://github.com/ben-eb/cssnano


### PR DESCRIPTION
There was a trailing parenthesis in the link ;)

Thank you for this great recap  ;)
